### PR TITLE
Fix implicit nullable parameter types for PHP 8.4 compatibility

### DIFF
--- a/src/Inventory/GetAllInventory.php
+++ b/src/Inventory/GetAllInventory.php
@@ -24,14 +24,14 @@ class GetAllInventory extends Core
      * @return object|string
      */
     public function sendRequest(
-        int $page = null,
-        int $limit = null,
-        string $warehouse_uuid = null,
-        string $sku = null,
-        string $created_at_min = null,
-        string $created_at_max = null,
-        string $updated_at_min = null,
-        string $updated_at_max = null
+        ?int $page = null,
+        ?int $limit = null,
+        ?string $warehouse_uuid = null,
+        ?string $sku = null,
+        ?string $created_at_min = null,
+        ?string $created_at_max = null,
+        ?string $updated_at_min = null,
+        ?string $updated_at_max = null
     ) {
         // Build the API endpoint
         $url = self::BASE_URI . 'inventory';

--- a/src/Inventory/PatchInventory.php
+++ b/src/Inventory/PatchInventory.php
@@ -20,7 +20,7 @@ class PatchInventory extends Core
     * @throws \Exception
     * @throws \GuzzleHttp\Exception\GuzzleException
     */
-    public function sendRequest(array $invArr = null)
+    public function sendRequest(?array $invArr = null)
     {
         if (count($invArr['inventory']) > 50)
             throw new \Exception("You may only PATCH up to 50 individual inventories at a time.");

--- a/src/Inventory/PostInventory.php
+++ b/src/Inventory/PostInventory.php
@@ -18,7 +18,7 @@ class PostInventory extends Core
      *
      * @return string|object
      */
-    public function sendRequest(array $invArr = null)
+    public function sendRequest(?array $invArr = null)
     {
         // Build the API endpoint
         $url = self::BASE_URI . 'inventory';

--- a/src/Inventory/PutInventory.php
+++ b/src/Inventory/PutInventory.php
@@ -13,7 +13,7 @@ class PutInventory extends Core
      *
      * @return string|object
      */
-    public function sendRequest(array $invArr = null)
+    public function sendRequest(?array $invArr = null)
     {
         // Build the API endpoint
         $url = self::BASE_URI . 'inventory';

--- a/src/Orders/GetAllOrders.php
+++ b/src/Orders/GetAllOrders.php
@@ -25,13 +25,13 @@ class GetAllOrders extends Core
      * @return object|string
      */
     public function sendRequest(
-        int $page = null,
-        int $limit = null,
-        string $min_ordered_at = null,
-        string $max_ordered_at = null,
-        string $sb_status = null,
-        string $sb_payment_status = null,
-        string $shipment_status = null
+        ?int $page = null,
+        ?int $limit = null,
+        ?string $min_ordered_at = null,
+        ?string $max_ordered_at = null,
+        ?string $sb_status = null,
+        ?string $sb_payment_status = null,
+        ?string $shipment_status = null
     ) {
         // Build the API endpoint
         $url = self::BASE_URI . 'orders';

--- a/src/Orders/GetOrder.php
+++ b/src/Orders/GetOrder.php
@@ -13,7 +13,7 @@ class GetOrder extends Core
      *
      * @return string
      */
-    public function sendRequest(string $sb_order_seq = null) {
+    public function sendRequest(?string $sb_order_seq = null) {
 
         if (is_null($sb_order_seq) === true)
             throw new \Exception('You failed to supply a Sellbrite Order Sequence number.');

--- a/src/Products/DeleteProduct.php
+++ b/src/Products/DeleteProduct.php
@@ -14,7 +14,7 @@ class DeleteProduct extends Core
     /**
      * @param string $sku The SKU of the product
      */
-    public function sendRequest(string $sku = null)
+    public function sendRequest(?string $sku = null)
     {
         if (is_null($sku) === true || empty($sku) === true || is_string($sku) === false)
             throw new \Exception('You failed to supply a SKU.');

--- a/src/Products/GetProduct.php
+++ b/src/Products/GetProduct.php
@@ -17,8 +17,8 @@ class GetProduct extends Core
      * @param array   $skuArr An array of SKUs
      */
     public function sendRequest(
-        int $page = null,
-        int $limit = null,
+        ?int $page = null,
+        ?int $limit = null,
         array $skuArr = []
     ) {
         // Build the API endpoint

--- a/src/Products/PostProduct.php
+++ b/src/Products/PostProduct.php
@@ -15,7 +15,7 @@ class PostProduct extends Core
      * @param string $sku The SKU of the product
      * @param array $productInfoArr An array containing all the info related to the product
      */
-    public function sendRequest(string $sku = null, array $productInfoArr = null)
+    public function sendRequest(?string $sku = null, ?array $productInfoArr = null)
     {
         if (is_null($sku) === true || empty($sku) === true || is_string($sku) === false)
             throw new \Exception('You failed to supply a SKU.');

--- a/src/Shipments/PostShipment.php
+++ b/src/Shipments/PostShipment.php
@@ -11,7 +11,7 @@ class PostShipment extends Core
     /**
      *
      */
-    public function sendRequest(array $shipmentArray = null)
+    public function sendRequest(?array $shipmentArray = null)
     {
         // Build the API endpoint
         $url = self::BASE_URI . 'shipments';

--- a/src/VariationGroups/DeleteVariationGroup.php
+++ b/src/VariationGroups/DeleteVariationGroup.php
@@ -16,7 +16,7 @@ class DeleteVariationGroup extends Core
      * @param integer $limit Number of results per page
      * @param array   $skuArr An array of SKUs
      */
-    public function sendRequest(string $sku = null)
+    public function sendRequest(?string $sku = null)
     {
         if (is_null($sku) === true || empty($sku) === true || is_string($sku) === false)
             throw new \Exception('You failed to supply a SKU.');

--- a/src/VariationGroups/GetVariationGroup.php
+++ b/src/VariationGroups/GetVariationGroup.php
@@ -17,8 +17,8 @@ class GetVariationGroup extends Core
      * @param array   $skuArr An array of SKUs
      */
     public function sendRequest(
-        int $page = null,
-        int $limit = null,
+        ?int $page = null,
+        ?int $limit = null,
         array $skuArr = []
     ) {
         // Build the API endpoint

--- a/src/VariationGroups/PutVariationGroup.php
+++ b/src/VariationGroups/PutVariationGroup.php
@@ -20,11 +20,11 @@ class PutVariationGroup extends Core
      * @param array   $images Array of image URLs
      */
     public function sendRequest(
-        string $sku = null,
-        string $name = null,
+        ?string $sku = null,
+        ?string $name = null,
         array $childSKUs = array(),
         array $variationAttr = array(),
-        string $description = null,
+        ?string $description = null,
         array $images = array()
     ) {
         if (is_null($sku) === true || empty($sku) === true || is_string($sku) === false)

--- a/src/Warehouses/GetWarehouseFulfillments.php
+++ b/src/Warehouses/GetWarehouseFulfillments.php
@@ -26,14 +26,14 @@ class GetWarehouseFulfillments extends Core
      * @return object|string
      */
     public function sendRequest(
-        string $warehouseUuid = null,
-        int $page = null,
-        int $limit = null,
-        string $min_ordered_at = null,
-        string $max_ordered_at = null,
-        string $sb_status = null,
-        string $sb_payment_status = null,
-        string $shipment_status = null
+        ?string $warehouseUuid = null,
+        ?int $page = null,
+        ?int $limit = null,
+        ?string $min_ordered_at = null,
+        ?string $max_ordered_at = null,
+        ?string $sb_status = null,
+        ?string $sb_payment_status = null,
+        ?string $shipment_status = null
     ) {
         if (is_null($warehouseUuid) === true || empty($warehouseUuid) === true)
             throw new \Exception('You have to supply a warehouse uuid for this API request');

--- a/src/Warehouses/PostWarehouse.php
+++ b/src/Warehouses/PostWarehouse.php
@@ -11,7 +11,7 @@ class PostWarehouse extends Core
     /**
      * @param array $warehouseInfoArr Array that holds all the information for the associated warehouse
      */
-    public function sendRequest(array $warehouseInfoArr = null)
+    public function sendRequest(?array $warehouseInfoArr = null)
     {
         if (is_null($warehouseInfoArr) === true || empty($warehouseInfoArr) === true)
             throw new \Exception('You have to supply an appropriate warehouse information array.');

--- a/src/Warehouses/PutWarehouse.php
+++ b/src/Warehouses/PutWarehouse.php
@@ -11,7 +11,7 @@ class PutWarehouse extends Core
     /**
      * @param array $warehouseInfoArr Array that holds all the information for the associated warehouse
      */
-    public function sendRequest(string $warehouseUuid = null, array $warehouseInfoArr = null)
+    public function sendRequest(?string $warehouseUuid = null, ?array $warehouseInfoArr = null)
     {
         if (is_null($warehouseUuid) === true || empty($warehouseUuid) === true)
             throw new \Exception('You have to supply a warehouse uuid for this API request');


### PR DESCRIPTION
Add explicit `?` nullable type prefix to all parameters that have a typed hint with `= null` default value. This pattern is deprecated in PHP 8.4 and will become an error in future versions.